### PR TITLE
Add .gitattributes to fix GDScript language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gd linguist-language=GDScript


### PR DESCRIPTION
This fixes language detection so that `*.gd` files are detected as GDScript instead of GAP.

**Note:** The result of this pull request isn't visible on my fork, as it's not on the `master` branch.